### PR TITLE
Change to specify target branch to nyon.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,5 @@ updates:
     day: "monday"
     time: "06:00"
     timezone: "Asia/Tokyo"
+    target_branch: "nyon"
   open-pull-requests-limit: 99


### PR DESCRIPTION
Change to specify target branch to nyon.
Because today's Dependabot changed the target branch without permission.