### PR TITLE
Revert "Bump highlight.js from 10.6.0 to 11.4.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
 		"gulp-tslint": "8.1.4",
 		"gulp-typescript": "5.0.1",
 		"hard-source-webpack-plugin": "0.13.1",
-		"highlight.js": "11.4.0",
+		"highlight.js": "10.6.0",
 		"hpagent": "0.1.2",
 		"html-minifier": "4.0.0",
 		"http-signature": "1.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4289,10 +4289,10 @@ he@1.2.0, he@^1.1.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@11.4.0:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.4.0.tgz#34ceadd49e1596ee5aba3d99346cdfd4845ee05a"
-  integrity sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==
+highlight.js@10.6.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.6.0.tgz#0073aa71d566906965ba6e1b7be7b2682f5e18b6"
+  integrity sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==
 
 highlight.js@^10.7.1:
   version "10.7.2"


### PR DESCRIPTION
Reverts mayaeh/misskey-v11#1016

#1016 has broken WebUI.
However, if you comment out [`Vue.use(hljs.vuePlugin);`](https://github.com/mayaeh/misskey-v11/blob/nyon/src/client/app/init.ts#L302), it works normally.

Or we have the option of using [`@highlightjs/vue-plugin`](https://github.com/highlightjs/vue-plugin).
However, recent versions don't seem to support Vue v2.x.